### PR TITLE
Refactored handles to be objects which contain a .drop() method. 

### DIFF
--- a/db/low-level/index.ts
+++ b/db/low-level/index.ts
@@ -19,10 +19,11 @@ import { NfsClient, NfsDirectoryClient, NfsFileClient, NfsDirectoryData,
 import { AppendableDataClient } from "./src/ts/appendable-data";
 import { StructuredDataClient } from "./src/ts/structured-data"
 import { DataIDClient } from "./src/ts/data-id";
+import { Drop, withDrop, withDropP } from "./src/ts/raii";
 
 export { NfsClient, NfsFileClient, NfsDirectoryClient,
          NfsDirectoryData, NfsDirectoryInfo, NfsFileData, AuthorizationPayload,
-         AuthResponse
+         AuthResponse, Drop, withDrop, withDropP
        };
 
 

--- a/db/low-level/spec/appendable_data_client_spec.ts
+++ b/db/low-level/spec/appendable_data_client_spec.ts
@@ -10,22 +10,22 @@ describe("An appendable data client", () => {
     it("can create an appendable data, and drop it", async (done) => {
         const appdat: AppendableDataHandle =
             await failDone(client.ad.create("Some name" + makeid()), done);
-        await failDone(client.ad.save(appdat), done);
-        await failDone(client.ad.drop(appdat), done);
+        await failDone(appdat.save(), done);
+        await failDone(appdat.drop(), done);
         done();
     });
 
     it("can read the metadata of a fresh appendable data", async (done) => {
         const appDataID: AppendableDataHandle =
             await failDone(client.ad.create("Some name" + makeid()), done);
-        await failDone(client.ad.save(appDataID), done);
+        await failDone(appDataID.save(), done);
         const metadata: AppedableDataMetadata =
-            await failDone(client.ad.getMetadata(appDataID), done);
+            await failDone(appDataID.getMetadata(), done);
 
         expect(metadata.dataLength).toBe(0);
         expect(metadata.isOwner).toBe(true);
 
-        await failDone(client.ad.drop(appDataID), done);
+        await failDone(appDataID.drop(), done);
 
         done();
     });
@@ -34,7 +34,7 @@ describe("An appendable data client", () => {
         const appDataID: AppendableDataHandle =
             await failDone(client.ad.create("Some name" + makeid()), done);
         const dataID: DataIDHandle =
-            await failDone(client.ad.toDataIdHandle(appDataID), done);
+            await failDone(appDataID.toDataIdHandle(), done);
         done();
     });
 
@@ -42,10 +42,10 @@ describe("An appendable data client", () => {
         const appDataID: AppendableDataHandle =
             await failDone(client.ad.create("Some name" + makeid()), done);
 
-        await failDone(client.ad.save(appDataID), done);
+        await failDone(appDataID.save(), done);
 
         const dataID: DataIDHandle =
-            await failDone(client.ad.toDataIdHandle(appDataID), done);
+            await failDone(appDataID.toDataIdHandle(), done);
 
         const res: FromDataIDHandleResponse =
             await failDone(client.ad.fromDataIdHandle(dataID), done);
@@ -59,26 +59,26 @@ describe("An appendable data client", () => {
         // make the appendable data and save it to the network
         const parent: AppendableDataHandle =
             await failDone(client.ad.create(parentName), done);
-        await failDone(client.ad.save(parent), done);
+        await failDone(parent.save(), done);
 
         const parentDataID: DataIDHandle =
-            await failDone(client.ad.toDataIdHandle(parent), done);
+            await failDone(parent.toDataIdHandle(), done);
 
         // make the structured data, and save it to the network
         const child: StructuredDataHandle =
             await failDone(client.structured.create(
                 childName, TYPE_TAG_VERSIONED, {"child": true}), done);
-        await failDone(client.structured.save(child), done);
+        await failDone(child.save(), done);
 
         // append the data, creating a cleaning up a dataID handle along the way
         const childDataID: DataIDHandle =
-            await failDone(client.structured.toDataIdHandle(child), done);
-        await failDone(client.ad.append(parent, childDataID), done);
-        await failDone(client.dataID.drop(childDataID), done);
-        await failDone(client.structured.drop(child), done);
+            await failDone(child.toDataIdHandle(), done);
+        await failDone(parent.append(childDataID), done);
+        await failDone(childDataID.drop(), done);
+        await failDone(child.drop(), done);
 
         // drop the parent handle so that we can refresh it
-        await failDone(client.ad.drop(parent), done);
+        await failDone(parent.drop(), done);
 
         const refreshedParent: FromDataIDHandleResponse =
             await failDone(client.ad.fromDataIdHandle(parentDataID), done);
@@ -86,16 +86,16 @@ describe("An appendable data client", () => {
         const refreshedParrentHandle: AppendableDataHandle = refreshedParent.handleId;
 
         const childDataId2: DataIDHandle =
-            await failDone(client.ad.at(refreshedParrentHandle, 0), done);
+            await failDone(refreshedParrentHandle.at(0), done);
         const child2: StructuredDataHandle =
             (await failDone(client.structured.fromDataIdHandle(childDataId2), done)).handleId;
-        const childContent = await failDone(client.structured.readAsObject(child2), done);
+        const childContent = await failDone(child2.readAsObject(), done);
         expect(childContent.child).toBe(true);
 
-        await failDone(client.structured.drop(child2), done);
-        await failDone(client.ad.drop(refreshedParent.handleId), done);
-        await failDone(client.dataID.drop(childDataId2), done);
-        await failDone(client.dataID.drop(parentDataID), done);
+        await failDone(child2.drop(), done);
+        await failDone(refreshedParent.handleId.drop(), done);
+        await failDone(childDataId2.drop(), done);
+        await failDone(parentDataID.drop(), done);
 
         done();
     });

--- a/db/low-level/spec/data_id_spec.ts
+++ b/db/low-level/spec/data_id_spec.ts
@@ -8,10 +8,12 @@ describe("A data id client", () => {
         const appDataID: AppendableDataHandle =
             await failDone(client.ad.create("Some random name"), done);
         const dataID: DataIDHandle =
-            await failDone(client.ad.toDataIdHandle(appDataID), done);
+            await failDone(appDataID.toDataIdHandle(), done);
 
         const serialised: Buffer =
-            await failDone(client.dataID.serialise(dataID), done);
+            await failDone(dataID.serialise(), done);
+
+        await failDone(dataID.drop(), done);
         done();
     });
 
@@ -19,12 +21,14 @@ describe("A data id client", () => {
         const appDataID: AppendableDataHandle =
             await failDone(client.ad.create("Some random name"), done);
         const dataID: DataIDHandle =
-            await failDone(client.ad.toDataIdHandle(appDataID), done);
+            await failDone(appDataID.toDataIdHandle(), done);
 
         const serialised: Buffer =
-            await failDone(client.dataID.serialise(dataID), done);
+            await failDone(dataID.serialise(), done);
         const deserialised: DataIDHandle =
             await failDone(client.dataID.deserialise(serialised), done);
+
+        await failDone(dataID.drop(), done);
 
         done();
     });

--- a/db/low-level/spec/nfs_client_spec.ts
+++ b/db/low-level/spec/nfs_client_spec.ts
@@ -1,148 +1,148 @@
 
-import { makeid, client, TEST_DATA_DIR, exists, failDone } from './test_util';
-import { AuthorizationPayload } from '../src/ts/auth';
-import { NfsClient, NfsDirectoryInfo, SafeFile } from '../src/ts/nfs';
-import * as stream from 'stream';
-import * as fs from 'fs';
+import { makeid, client, TEST_DATA_DIR, exists, failDone } from "./test_util";
+import { AuthorizationPayload } from "../src/ts/auth";
+import { NfsClient, NfsDirectoryInfo, SafeFile } from "../src/ts/nfs";
+import * as stream from "stream";
+import * as fs from "fs";
 
 
-describe('An nfs directory client', () => {
+describe("An nfs directory client", () => {
 
-    it('can check to see if a non-existant directory exists', (done) => {(async function() {
-        const dirResponse : Promise<NfsDirectoryInfo> =
-            client.nfs.dir.get('app', 'safe-client-test-bogus').catch((err) => {
+    it("can check to see if a non-existant directory exists", async (done) => {
+        const dirResponse: Promise<NfsDirectoryInfo> =
+            client.nfs.dir.get("app", "safe-client-test-bogus").catch((err) => {
                 expect(err.res.statusCode).toBe(404);
                 done();
             });
 
-    })()});
+    });
 
-    it('can make a new directory', (done) => {(async function() {
-        await client.nfs.dir.create('app', makeid(), true).catch((err) => {
+    it("can make a new directory", async (done) => {
+        await client.nfs.dir.create("app", makeid(), true).catch((err) => {
             fail(err);
             done();
         });
 
         done();
-    })()});
+    });
 
-    it('can check to see if a freshly created directory exists', (done) => {(async function() {
-        const dir : string = makeid();
+    it("can check to see if a freshly created directory exists", async (done) => {
+        const dir: string = makeid();
 
-        await client.nfs.dir.create('app', dir, true).catch((err) => {
+        await client.nfs.dir.create("app", dir, true).catch((err) => {
             fail(err);
             done();
         });
 
-        const dirResponse : NfsDirectoryInfo = await client.nfs.dir.get('app', dir);
+        const dirResponse: NfsDirectoryInfo = await client.nfs.dir.get("app", dir);
 
         expect(dirResponse.info.name).toBe(dir);
         expect(dirResponse.info.isPrivate).toBe(true);
 
         done();
-    })()});
+    });
 
-    it('can delete a directory', (done) => {(async function() {
-        const dir : string = makeid();
+    it("can delete a directory", async (done) => {
+        const dir: string = makeid();
 
-        await client.nfs.dir.create('app', dir, true).catch((err) => {
+        await client.nfs.dir.create("app", dir, true).catch((err) => {
             fail(err);
             done();
         });
 
-        await client.nfs.dir.delete('app', dir).catch((err) => {
+        await client.nfs.dir.delete("app", dir).catch((err) => {
             fail(err);
             done();
         });
 
-        client.nfs.dir.get('app', dir).catch((err) => {
+        client.nfs.dir.get("app", dir).catch((err) => {
             expect(err.res.statusCode).toBe(404);
             done();
         });
 
-    })()});
+    });
 
-    it('can update a directories name', (done) => {(async function() {
-        const firstDirName : string = makeid();
-        const secondDirName : string = makeid();
+    it("can update a directories name", async (done) => {
+        const firstDirName: string = makeid();
+        const secondDirName: string = makeid();
 
-        await client.nfs.dir.create('app', firstDirName, true).catch((err) => {
+        await client.nfs.dir.create("app", firstDirName, true).catch((err) => {
             fail(err);
             done();
         });
 
-        await client.nfs.dir.update('app', firstDirName, secondDirName).catch((err) => {
+        await client.nfs.dir.update("app", firstDirName, secondDirName).catch((err) => {
             fail(err);
             done();
         });
 
-        const dirInfo : NfsDirectoryInfo = await client.nfs.dir.get('app', secondDirName);
+        const dirInfo: NfsDirectoryInfo = await client.nfs.dir.get("app", secondDirName);
 
         expect(dirInfo.info.name).toBe(secondDirName);
 
         done();
 
-    })()});
+    });
 
-    it('can move a directory', (done) => {(async function() {
-        const firstDirName : string = makeid();
-        const secondDirName : string = makeid();
+    it("can move a directory", async (done) => {
+        const firstDirName: string = makeid();
+        const secondDirName: string = makeid();
 
-        await client.nfs.dir.create('app', '/' + firstDirName, true).catch((err) => {
+        await client.nfs.dir.create("app", "/" + firstDirName, true).catch((err) => {
             fail(err); done();
         });
 
-        await client.nfs.dir.create('app', '/' + secondDirName, true).catch((err) => {
+        await client.nfs.dir.create("app", "/" + secondDirName, true).catch((err) => {
             fail(err); done();
         });
 
-        await client.nfs.dir.move('app', `/${firstDirName}`,
-                                  'app', `/${secondDirName}`)
+        await client.nfs.dir.move("app", `/${firstDirName}`,
+                                  "app", `/${secondDirName}`)
             .catch((err) => { fail(err); done(); });
 
 
-        const dirInfo : NfsDirectoryInfo =
-            await client.nfs.dir.get('app', `/${secondDirName}`).catch((err) => {
+        const dirInfo: NfsDirectoryInfo =
+            await client.nfs.dir.get("app", `/${secondDirName}`).catch((err) => {
                 fail(err); done(); throw err;
             });
         expect(
             exists(dirInfo.subDirectories, (dir) => {
-                return dir.name == firstDirName;
+                return dir.name === firstDirName;
             })
         ).toBe(true);
 
         done();
 
-    })()});
+    });
 
 
-    it('can copy a directory', (done) => {(async function() {
-        const firstDirName : string = makeid();
-        const secondDirName : string = makeid();
+    it("can copy a directory", async (done) => {
+        const firstDirName: string = makeid();
+        const secondDirName: string = makeid();
 
-        await client.nfs.dir.create('app', '/' + firstDirName, true).catch((err) => {
+        await client.nfs.dir.create("app", "/" + firstDirName, true).catch((err) => {
             fail(err); done();
         });
-        await client.nfs.dir.create('app', '/' + secondDirName, true).catch((err) => {
+        await client.nfs.dir.create("app", "/" + secondDirName, true).catch((err) => {
             fail(err); done();
         });
 
-        await client.nfs.dir.copy('app', `/${firstDirName}`,
-                                  'app', `/${secondDirName}`)
+        await client.nfs.dir.copy("app", `/${firstDirName}`,
+                                  "app", `/${secondDirName}`)
             .catch((err) => { fail(err); done(); });
 
-        const tgtDirInfo : NfsDirectoryInfo =
-            await client.nfs.dir.get('app', `/${secondDirName}`).catch((err) => {
+        const tgtDirInfo: NfsDirectoryInfo =
+            await client.nfs.dir.get("app", `/${secondDirName}`).catch((err) => {
                 fail(err); done(); throw err;
             });
         expect(
             exists(tgtDirInfo.subDirectories, (dir) => {
-                return dir.name == firstDirName;
+                return dir.name === firstDirName;
             })
         ).toBe(true);
 
-        const srcDirInfo : NfsDirectoryInfo =
-            await client.nfs.dir.get('app', `/${firstDirName}`).catch((err) => {
+        const srcDirInfo: NfsDirectoryInfo =
+            await client.nfs.dir.get("app", `/${firstDirName}`).catch((err) => {
                 fail(err); done(); throw err;
             });
 
@@ -150,17 +150,16 @@ describe('An nfs directory client', () => {
 
         done();
 
-    })()});
+    });
 
 });
 
 describe("An nfs file client", () => {
 
-    it('can upload a file to the network, and check that it is really there',
-       (done) => { (async function()
-    {
-        const filename : string = makeid() + '-invictus.txt';
-        let testStream : stream.Transform = new stream.PassThrough();
+    it("can upload a file to the network, and check that it is really there",
+       async (done) => {
+        const filename: string = makeid() + "-invictus.txt";
+        let testStream: stream.Transform = new stream.PassThrough();
 
         await new Promise( (resolve, reject) => {
             testStream.write(invictus, (err) => {
@@ -169,9 +168,9 @@ describe("An nfs file client", () => {
             });
         });
 
-        const mkFile : Promise<void> =
-            client.nfs.file.create('app', filename, testStream,
-                                   invictus.byteLength, 'text/plain');
+        const mkFile: Promise<void> =
+            client.nfs.file.create("app", filename, testStream,
+                                   invictus.byteLength, "text/plain");
 
         await mkFile.catch( (err) => {
             fail(err);
@@ -179,16 +178,16 @@ describe("An nfs file client", () => {
             done();
         });
 
-        const fileInfo = await client.nfs.file.get('app', filename);
+        const fileInfo = await client.nfs.file.get("app", filename);
         expect(fileInfo.body.equals(invictus)).toBe(true);
 
         done();
 
-    })()});
+    });
 
-    it('can delete files', (done) => {(async function() {
-        const filename : string = makeid() + '-invictus.txt';
-        let testStream : stream.Transform = new stream.PassThrough();
+    it("can delete files", async (done) => {
+        const filename: string = makeid() + "-invictus.txt";
+        let testStream: stream.Transform = new stream.PassThrough();
 
         await new Promise( (resolve, reject) => {
             testStream.write(invictus, (err) => {
@@ -197,54 +196,47 @@ describe("An nfs file client", () => {
             });
         });
 
-        await failDone(client.nfs.file.create('app', filename, testStream,
-                                                invictus.byteLength, 'text/plain'), done);
+        await failDone(client.nfs.file.create("app", filename, testStream,
+                                                invictus.byteLength, "text/plain"), done);
 
-        const fileInfo : SafeFile =
-            await failDone(client.nfs.file.get('app', filename), done);
+        const fileInfo: SafeFile =
+            await failDone(client.nfs.file.get("app", filename), done);
 
         expect(fileInfo.body.equals(invictus)).toBe(true);
 
-        await failDone(client.nfs.file.delete('app', filename), done);
+        await failDone(client.nfs.file.delete("app", filename), done);
 
-        const newFileInfo : SafeFile =
-            await client.nfs.file.get('app', filename).catch( (err) => {
-                expect(err.res.statusCode).toBe(404);
-                done();
-                throw err;
-            });
-
-        fail("file is still there!");
-        done();
-
-    })()});
-
-    it('can handle image files as well as text blocks',
-       (done) => {(async function()
-    {
-        const remotePath : string = makeid() + '-jesus.jpg';
-        const localPath : string = TEST_DATA_DIR + '/jesus.jpg';
-
-        let fileSize : number = fs.statSync(localPath).size;
-        let testStream : stream.Readable = fs.createReadStream(localPath);
-
-        const mkFile : Promise<void> =
-            client.nfs.file.create('app', remotePath, testStream,
-                                   fileSize, 'image/jpg');
-
-        await mkFile.catch( (err) => {
-            fail(err);
+        let it404d: boolean = false; // weird timing hack
+        await client.nfs.file.get("app", filename).catch( (err) => {
+            expect(err.res.statusCode).toBe(404);
+            it404d = true;
             done();
         });
 
-        const fileInfo = await client.nfs.file.get('app', remotePath);
+        expect(it404d).toBe(true);
+        done();
+
+    });
+
+    it("can handle image files as well as text blocks", async (done) => {
+        const remotePath: string = makeid() + "-jesus.jpg";
+        const localPath: string = TEST_DATA_DIR + "/jesus.jpg";
+
+        let fileSize: number = fs.statSync(localPath).size;
+        let testStream: stream.Readable = fs.createReadStream(localPath);
+
+        await failDone(client.nfs.file.create("app", remotePath, testStream,
+                                            fileSize, "image/jpg"), done);
+
+        const fileInfo = await client.nfs.file.get("app", remotePath);
+
 
         // For some baffling reason, typescript wails when I annotate this with
         // the buffer type, but everything seems to work anyway. Please forgive the
         // typecasting.
-        const imgBuffer : Buffer = <Buffer>await new Promise( (resolve, reject) => {
-            const lpath : string = localPath; // typescript automatically caught this js closure bug #blessed
-            fs.readFile(lpath, (err : NodeJS.ErrnoException, data : Buffer) => {
+        const imgBuffer: Buffer = <Buffer>await new Promise( (resolve, reject) => {
+            const lpath: string = localPath; // typescript automatically caught this js closure bug #blessed
+            fs.readFile(lpath, (err: NodeJS.ErrnoException, data: Buffer) => {
                 if (err) reject(err);
                 else resolve(data);
             });
@@ -254,13 +246,13 @@ describe("An nfs file client", () => {
 
         done();
 
-    })()});
+    });
 
 
 });
 
 // Buffer.from requires node --version to be >= 6.0.0
-const invictus : Buffer = Buffer.from(`
+const invictus: Buffer = Buffer.from(`
 Out of the night that covers me,
 Black as the pit from pole to pole,
 I thank whatever gods may be

--- a/db/low-level/spec/safe_client_spec.ts
+++ b/db/low-level/spec/safe_client_spec.ts
@@ -1,20 +1,20 @@
 
-import { client } from './test_util';
+import { client } from "./test_util";
 
-describe('A SafeClient ', () => {
+describe("A SafeClient ", () => {
 
     // smoke test
-    it('can authenticate with the safe_launcher', (done) => {
+    it("can authenticate with the safe_launcher", (done) => {
         (async function() {
 
             client.authResponse.catch( (err) => {
                 expect(err).toBe(undefined);
-            })
+            });
 
             expect(await client.authenticated()).toBe(true);
 
             done();
         })();
     });
-    
+
 });

--- a/db/low-level/spec/structured_data_spec.ts
+++ b/db/low-level/spec/structured_data_spec.ts
@@ -12,8 +12,8 @@ describe("A structured data client", () => {
         const structuredData: StructuredDataHandle =
             await failDone(client.structured.create(
                 "Some Name" + makeid(), TYPE_TAG_VERSIONED, JSON.stringify(data)), done);
-        await failDone(client.structured.save(structuredData), done);
-        await failDone(client.structured.drop(structuredData), done);
+        await failDone(structuredData.save(), done);
+        await failDone(structuredData.drop(), done);
 
         done();
     });
@@ -24,8 +24,8 @@ describe("A structured data client", () => {
         const structuredData: StructuredDataHandle =
             await failDone(client.structured.create(
                 "Some Name" + makeid(), TYPE_TAG_VERSIONED, Buffer.from(JSON.stringify(data))), done);
-        await failDone(client.structured.save(structuredData), done);
-        await failDone(client.structured.drop(structuredData), done);
+        await failDone(structuredData.save(), done);
+        await failDone(structuredData.drop(), done);
 
         done();
     });
@@ -36,8 +36,8 @@ describe("A structured data client", () => {
         const structuredData: StructuredDataHandle =
             await failDone(client.structured.create(
                 "Some Name" + makeid(), TYPE_TAG_VERSIONED, data), done);
-        await failDone(client.structured.save(structuredData), done);
-        await failDone(client.structured.drop(structuredData), done);
+        await failDone(structuredData.save(), done);
+        await failDone(structuredData.drop(), done);
 
         done();
     });
@@ -49,16 +49,16 @@ describe("A structured data client", () => {
         const structuredData: StructuredDataHandle =
             await failDone(client.structured.create(
                 "Some Name" + makeid(), TYPE_TAG_VERSIONED, JSON.stringify(data)), done);
-        await failDone(client.structured.save(structuredData), done);
+        await failDone(structuredData.save(), done);
 
         const dataID: DataIDHandle =
-            await failDone(client.structured.toDataIdHandle(structuredData), done);
+               await failDone(structuredData.toDataIdHandle(), done);
         const anotherStructuredData: FromDataIDHandleReponse =
             await failDone(client.structured.fromDataIdHandle(dataID), done);
 
-        await failDone(client.structured.drop(structuredData), done);
-        await failDone(client.structured.drop(anotherStructuredData.handleId), done);
-        await failDone(client.dataID.drop(dataID), done);
+        await failDone(structuredData.drop(), done);
+        await failDone(anotherStructuredData.handleId.drop(), done);
+        await failDone(dataID.drop(), done);
 
         done();
     });
@@ -69,11 +69,11 @@ describe("A structured data client", () => {
         const structuredData: StructuredDataHandle =
             await failDone(client.structured.create(
                 "Some Name" + makeid(), TYPE_TAG_VERSIONED, JSON.stringify(data)), done);
-        await failDone(client.structured.save(structuredData), done);
+        await failDone(structuredData.save(), done);
 
         const metadata: StructuredDataMetadata =
-            await failDone(client.structured.getMetadata(structuredData), done);
-        await failDone(client.structured.drop(structuredData), done);
+            await failDone(structuredData.getMetadata(), done);
+        await failDone(structuredData.drop(), done);
 
         done();
     });
@@ -82,13 +82,13 @@ describe("A structured data client", () => {
         const structuredData: StructuredDataHandle =
             await failDone(client.structured.create(
                 "Some Name" + makeid(), TYPE_TAG_VERSIONED, {"hello": "world"}), done);
-        await failDone(client.structured.save(structuredData), done);
+        await failDone(structuredData.save(), done);
 
         const result: any =
-            await failDone(client.structured.readAsObject(structuredData), done);
+            await failDone(structuredData.readAsObject(), done);
         expect(result.hello).toBe("world");
 
-        await failDone(client.structured.drop(structuredData), done);
+        await failDone(structuredData.drop(), done);
 
         done();
     });
@@ -97,13 +97,13 @@ describe("A structured data client", () => {
         const structuredData: StructuredDataHandle =
             await failDone(client.structured.create(
                 "Some Name" + makeid(), TYPE_TAG_VERSIONED, "hello world"), done);
-        await failDone(client.structured.save(structuredData), done);
+        await failDone(structuredData.save(), done);
 
         const result: any =
-            await failDone(client.structured.read(structuredData), done);
+            await failDone(structuredData.read(), done);
         expect(result).toBe("hello world");
 
-        await failDone(client.structured.drop(structuredData), done);
+        await failDone(structuredData.drop(), done);
 
         done();
     });

--- a/db/low-level/spec/test_util.ts
+++ b/db/low-level/spec/test_util.ts
@@ -1,11 +1,11 @@
 
-const mkpath = require('mkpath');
-import { AuthorizationPayload, AuthResponse } from '../src/ts/auth';
-import { SafeClient } from '../index';
-import { ApiClientConfig } from '../src/ts/client';
-import * as stream from 'stream';
+const mkpath = require("mkpath");
+import { AuthorizationPayload, AuthResponse } from "../src/ts/auth";
+import { SafeClient } from "../index";
+import { ApiClientConfig } from "../src/ts/client";
+import * as stream from "stream";
 
-const testAuthPayload : AuthorizationPayload = {
+const testAuthPayload: AuthorizationPayload = {
     "app": {
         "name": "Safe Client Test",
         "id": "fee.fi.fo.fum",
@@ -18,15 +18,14 @@ const testAuthPayload : AuthorizationPayload = {
     ]
 };
 
-const endpoint : string = 'http://localhost:8100';
+const endpoint : string = "http://localhost:8100";
 
 // for generating a tmp file to use in caching
-export function makeid()
-{
-    var text = "";
-    var possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+export function makeid() {
+    let text = "";
+    let possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 
-    for( var i=0; i < 15; i++ )
+    for (let i = 0; i < 15; i++ )
         text += possible.charAt(Math.floor(Math.random() * possible.length));
 
     return text;

--- a/db/low-level/src/ts/data-id.ts
+++ b/db/low-level/src/ts/data-id.ts
@@ -10,39 +10,18 @@
  */
 
 import { ApiClient, ApiClientConfig } from "./client";
-import { saneResponse, SafeError, UnexpectedResponseContent } from "./util";
+import { saneResponse, SafeError, UnexpectedResponseContent
+         , InvalidHandleError } from "./util";
 import * as WebRequest from "web-request";
 import { Response, Request } from "web-request";
 import * as stream from "stream";
-
-export type DataIDHandle = number;
+import { Handle } from "./raii";
 
 export class DataIDClient extends ApiClient {
 
     constructor(conf: ApiClientConfig) {
         super(conf);
     }
-
-    /**
-    *
-    * @param handleId - a handleId as obtained by creating and appendable or
-    *                   structured data, and then converting it to a data-id.
-    *                   This can be confusing, so see the tests in
-    *                   `spec/data_id_spec.ts` for an example.
-    * @returns The serialized handleId
-    */
-    public async serialise(handleId: DataIDHandle): Promise<Buffer> {
-        const res: Response<string> =
-            await saneResponse(WebRequest.create<string>(
-            `${this.endpoint}/data-id/${handleId}`, {
-                method: "GET",
-                auth: {
-                    bearer: (await this.authRes).token
-                }
-            }).response);
-
-        return Buffer.from(res.content);
-    };
 
     /**
     *
@@ -77,20 +56,51 @@ export class DataIDClient extends ApiClient {
         if (typeof resObj.handleId === "undefined") {
             throw new UnexpectedResponseContent(response);
         }
-        return resObj.handleId;
+
+        return new DataIDHandle(this, resObj.handleId);
+    }
+
+}
+
+
+export class DataIDHandle extends Handle {
+
+    constructor(c: ApiClient, handle: number) {
+        super(c, handle);
     }
 
     /**
+    *
+    * @returns The serialized handleId
+    */
+    public async serialise(): Promise<Buffer> {
+        if (!this.valid) throw new InvalidHandleError(this.handle);
+
+        const res: Response<string> =
+            await saneResponse(WebRequest.create<string>(
+            `${this.client.endpoint}/data-id/${this.handle}`, {
+                method: "GET",
+                auth: {
+                    bearer: (await this.client.authRes).token
+                }
+            }).response);
+
+        return Buffer.from(res.content);
+    }
+
+
+    /**
      *
-     * @param handle - the structured data handle
      */
-    public async drop(handle: DataIDHandle): Promise<void> {
+    protected async dropImpl(): Promise<void> {
+        if (!this.valid) throw new InvalidHandleError(this.handle);
+
         const result = await saneResponse(WebRequest.create<any>(
-            `${this.endpoint}/data-id/${handle}`, {
+            `${this.client.endpoint}/data-id/${this.handle}`, {
                 method: "DELETE",
                 json: true,
                 auth: {
-                    bearer: (await this.authRes).token
+                    bearer: (await this.client.authRes).token
                 }
             }).response);
         if (result.statusCode !== 200) {
@@ -100,6 +110,7 @@ export class DataIDClient extends ApiClient {
 
 
 }
+
 
 
 

--- a/db/low-level/src/ts/nfs.ts
+++ b/db/low-level/src/ts/nfs.ts
@@ -20,7 +20,7 @@ export class NfsClient extends ApiClient {
     public readonly dir: NfsDirectoryClient;
     public readonly file: NfsFileClient;
 
-    constructor(conf: ApiClientConfig){
+    constructor(conf: ApiClientConfig) {
         super(conf);
         this.dir = new NfsDirectoryClient(conf);
         this.file = new NfsFileClient(conf);
@@ -217,7 +217,6 @@ export class NfsFileClient extends ApiClient {
     public async create(rootPath: RootPath, filePath: string, file: NodeJS.ReadableStream,
                         size: number, contentType: string, metadata ?: Buffer): Promise<void>
     {
-
         let payload = {
             encoding: null,
             method: "POST",
@@ -235,7 +234,6 @@ export class NfsFileClient extends ApiClient {
         }
 
         const request = file.pipe(WebRequest.create(this.mkendpoint(rootPath, filePath), payload));
-
         const response = await saneResponse(request.response);
 
         if (response.statusCode !== 200) {

--- a/db/low-level/src/ts/raii.ts
+++ b/db/low-level/src/ts/raii.ts
@@ -1,0 +1,49 @@
+//
+// File: src/ts/raii.ts
+//
+// Try to hack some RAII principles into typescript to deal
+// with actually dropping the handles
+//
+
+import { ApiClient } from "./client";
+
+export interface Drop {
+    drop(): Promise<void>;
+}
+
+export async function withDrop<A extends Drop, B>(p: A, f: (x: A) => B): Promise<B> {
+    const ret: B = f(p);
+    await p.drop();
+    return ret;
+}
+
+export async function withDropP<A extends Drop, B>(p: A, f: (x: A) => Promise<B>): Promise<B> {
+    const ret: B = await f(p);
+    await p.drop();
+    return ret;
+}
+
+export abstract class Handle implements Drop {
+    // Provides some way to get access to the auth token.
+    // It is better to just store a reference in the handles
+    // because copying might get expensive, and the API
+    // client is supposed to live for the lifetime of the application.
+    readonly client: ApiClient;
+    readonly handle: number;
+
+    // A flag to make sure that no methods are called after drop
+    valid: boolean;
+
+    constructor(c: ApiClient, handle: number) {
+        this.client = c;
+        this.handle = handle;
+        this.valid = true;
+    }
+
+    public drop(): Promise<void> {
+        const p = this.dropImpl();
+        this.valid = false;
+        return p;
+    }
+    protected abstract dropImpl(): Promise<void>;
+}

--- a/db/low-level/src/ts/structured-data.ts
+++ b/db/low-level/src/ts/structured-data.ts
@@ -6,17 +6,16 @@ import { DataIDHandle } from "./data-id";
 import { CipherOptsHandle } from "./cipher-opts";
 import * as WebRequest from "web-request";
 import { Response } from "web-request";
+import { Handle } from "./raii";
 
 import * as crypto from "crypto";
 
 export type TypeTag = number;
 function isValidTypeTag(tt: TypeTag): boolean {
-    return (tt == 500 || tt == 501 || tt > 15000);
+    return (tt === 500 || tt === 501 || tt > 15000);
 }
 export const TYPE_TAG_UNVERSIONED: number = 500;
 export const TYPE_TAG_VERSIONED: number = 501;
-
-export type StructuredDataHandle = number;
 
 export interface StructuredDataMetadata {
     isOwner: boolean;
@@ -32,6 +31,13 @@ export interface FromDataIDHandleReponse extends StructuredDataMetadata {
     handleId: StructuredDataHandle;
 };
 function isFromDataIDHandleResponse(x: any): x is FromDataIDHandleReponse {
+    return typeof x.handleId !== "undefined" && isStructuredDataMetadata(x);
+}
+
+interface FromDataIDHandleReponseImpl extends StructuredDataMetadata {
+    handleId: number;
+};
+function isFromDataIDHandleResponseImpl(x: any): x is FromDataIDHandleReponseImpl {
     return typeof x.handleId !== "undefined" && isStructuredDataMetadata(x);
 }
 
@@ -58,8 +64,7 @@ export class StructuredDataClient extends ApiClient {
                         typeTag: TypeTag,
                         data: string | Buffer | Object,
                         cipherOpts: CipherOptsHandle = -1,
-                        version: number = 0): Promise<StructuredDataHandle>
-    {
+                        version: number = 0): Promise<StructuredDataHandle> {
         if (typeof name === "string") {
             name = crypto.createHash("sha256").update(name).digest("base64");
         }
@@ -98,21 +103,59 @@ export class StructuredDataClient extends ApiClient {
         if (typeof result.content.handleId === "undefined") {
             throw new UnexpectedResponseContent(result);
         }
-        return result.content.handleId;
+
+        return new StructuredDataHandle(this, result.content.handleId);
     }
 
     /**
      *
-     * @param handle - the appendable data handle
-     * @param httpMethod
+     * @param id - the data id handle to be converted
+     * @returns an appendable data id
      */
-    private async saveImpl(handle: StructuredDataHandle, httpMethod: "PUT" | "POST"): Promise<void> {
+    public async fromDataIdHandle(id: DataIDHandle): Promise<FromDataIDHandleReponse> {
+
         const result = await saneResponse(WebRequest.create<any>(
-            `${this.sdEndpoint}/${handle}`, {
-                method: httpMethod,
+            `${this.sdEndpoint}/handle/${id.handle}`, {
+                method: "GET",
                 json: true,
                 auth: {
                     bearer: (await this.authRes).token
+                }
+            }).response);
+
+        if (isFromDataIDHandleResponseImpl(result.content)) {
+            let res: FromDataIDHandleReponse = {
+                isOwner: result.content.isOwner,
+                version: result.content.version,
+                dataVersionLength: result.content.dataVersionLength,
+                handleId: new StructuredDataHandle(this, result.content.handleId)
+            };
+            return res;
+        } else {
+            throw new UnexpectedResponseContent(result);
+        }
+    }
+
+};
+
+
+export class StructuredDataHandle extends Handle {
+    readonly client: StructuredDataClient;
+    constructor(c: StructuredDataClient, handle: number) {
+        super(c, handle);
+    }
+
+    /**
+     *
+     * @param httpMethod
+     */
+    private async saveImpl(httpMethod: "PUT" | "POST"): Promise<void> {
+        const result = await saneResponse(WebRequest.create<any>(
+            `${this.client.sdEndpoint}/${this.handle}`, {
+                method: httpMethod,
+                json: true,
+                auth: {
+                    bearer: (await this.client.authRes).token
                 }
             }).response);
 
@@ -124,19 +167,17 @@ export class StructuredDataClient extends ApiClient {
     /**
      * Save a new appendable data
      *
-     * @param handle - the appendable data handle
      */
-    public async save(handle: StructuredDataHandle): Promise<void> {
-        return this.saveImpl(handle, "PUT");
+    public async save(): Promise<void> {
+        return this.saveImpl("PUT");
     }
 
     /**
      * Update an existing appendable data
      *
-     * @param handle - the appendable data handle
      */
-    public async update(handle: StructuredDataHandle): Promise<void> {
-        return this.saveImpl(handle, "POST");
+    public async update(): Promise<void> {
+        return this.saveImpl("POST");
     }
 
     /**
@@ -144,56 +185,33 @@ export class StructuredDataClient extends ApiClient {
      * @param id - the structured data id to be converted
      * @returns a data id referring to the appendable data
      */
-    public async toDataIdHandle(id: StructuredDataHandle): Promise<DataIDHandle> {
+    public async toDataIdHandle(): Promise<DataIDHandle> {
         const result = await saneResponse(WebRequest.create<any>(
-            `${this.sdEndpoint}/data-id/${id}`, {
+            `${this.client.sdEndpoint}/data-id/${this.handle}`, {
                 method: "GET",
                 json: true,
                 auth: {
-                    bearer: (await this.authRes).token
+                    bearer: (await this.client.authRes).token
                 }
             }).response);
 
         if (typeof result.content.handleId === "undefined") {
             throw new UnexpectedResponseContent(result);
         }
-        return result.content.handleId;
-    }
-    /**
-     *
-     * @param id - the data id handle to be converted
-     * @returns an appendable data id
-     */
-    public async fromDataIdHandle(id: DataIDHandle): Promise<FromDataIDHandleReponse> {
-
-        const result = await saneResponse(WebRequest.create<any>(
-            `${this.sdEndpoint}/handle/${id}`, {
-                method: "GET",
-                json: true,
-                auth: {
-                    bearer: (await this.authRes).token
-                }
-            }).response);
-
-        if (isFromDataIDHandleResponse(result.content)) {
-            return result.content;
-        } else {
-            throw new UnexpectedResponseContent(result);
-        }
+        return new DataIDHandle(this.client, result.content.handleId);
     }
 
     /**
      *
-     * @param handle - the structured data handle
      * @returns the metadata associated with the appendable data
      */
-    public async getMetadata(handle: StructuredDataHandle): Promise<StructuredDataMetadata> {
+    public async getMetadata(): Promise<StructuredDataMetadata> {
         const result = await saneResponse(WebRequest.create<any>(
-            `${this.sdEndpoint}/metadata/${handle}`, {
+            `${this.client.sdEndpoint}/metadata/${this.handle}`, {
                 method: "GET",
                 json: true,
                 auth: {
-                    bearer: (await this.authRes).token
+                    bearer: (await this.client.authRes).token
                 }
             }).response);
         if (isStructuredDataMetadata(result.content)) {
@@ -207,13 +225,13 @@ export class StructuredDataClient extends ApiClient {
      *
      * @param handle - the structured data handle
      */
-    public async drop(handle: StructuredDataHandle): Promise<void> {
+    protected async dropImpl(): Promise<void> {
         const result = await saneResponse(WebRequest.create<any>(
-            `${this.sdEndpoint}/handle/${handle}`, {
+            `${this.client.sdEndpoint}/handle/${this.handle}`, {
                 method: "DELETE",
                 json: true,
                 auth: {
-                    bearer: (await this.authRes).token
+                    bearer: (await this.client.authRes).token
                 }
             }).response);
         if (result.statusCode !== 200) {
@@ -223,18 +241,17 @@ export class StructuredDataClient extends ApiClient {
 
     /**
      *
-     * @param handle - the structured data handle
      * @param version - optional version number if the typeTag for this
      *                  appendable data is `TYPE_TAG_VERSIONED`
      */
-    public async read(handle: StructuredDataHandle, version ?: number): Promise<string> {
-        const endpoint = `${this.sdEndpoint}/${handle}`
+    public async read(version ?: number): Promise<string> {
+        const endpoint = `${this.client.sdEndpoint}/${this.handle}`
             + (typeof version === "undefined" ? "" : `/${version}`);
         const result: Response<any> = await saneResponse(WebRequest.create<any>(
             endpoint, {
                 method: "GET",
                 auth: {
-                    bearer: (await this.authRes).token
+                    bearer: (await this.client.authRes).token
                 }
             }).response);
         if (result.statusCode !== 200) {
@@ -246,15 +263,15 @@ export class StructuredDataClient extends ApiClient {
 
     /**
      *
-     * @param handle - the structured data handle
      * @param version - optional version number if the typeTag for this
      *                  appendable data is `TYPE_TAG_VERSIONED`
      */
-    public async readAsObject(handle: StructuredDataHandle, version ?: number): Promise<any> {
-        const res: string = await this.read(handle, version);
+    public async readAsObject(version ?: number): Promise<any> {
+        const res: string = await this.read(version);
 
         // the error condition is handled smoothly by the promise
         return JSON.parse(res);
     }
 
 };
+

--- a/db/low-level/src/ts/util.ts
+++ b/db/low-level/src/ts/util.ts
@@ -28,6 +28,12 @@ export class UnexpectedResponseContent extends SafeError {
     }
 }
 
+export class InvalidHandleError extends Error {
+    constructor(handle: number) {
+        super(`Handle=${handle} is invalid`);
+    }
+}
+
 // for use in a promise context
 export async function saneResponse<T>(response: Promise<Response<T>>): Promise<Response<T>> {
     return response.then( (res) => {


### PR DESCRIPTION
This will hopefully make it a little easier to make sure that we clean up after ourselves using the exported withDrop and withDropP functions.

This PR contains a lot of churn. I'm sorry about that :(. I figured that this was the last time I could justify a major factor of the low level API.