### PR TITLE
Consistent urlbar

### DIFF
--- a/app/client/components/Upload.tsx
+++ b/app/client/components/Upload.tsx
@@ -154,7 +154,6 @@ export class Upload extends React.Component<UploadProps, UploadState> {
             const xorName: SerializedDataID = await n.serialise();
             // TODO: stuff the link in the user profile
             const hash: string = xorName.toString("base64");
-            console.log(`uploaded video to: frames://${hash}`);
 
             if (this.props.redirect == null) {
                 this.context.router.history.push(`/watch/${hash}`);

--- a/app/client/components/Watch.tsx
+++ b/app/client/components/Watch.tsx
@@ -9,7 +9,7 @@ import { SerializedDataID, withDropP } from "safe-launcher-client";
 import { ChasingArrowsLoadingImage } from "./Animations";
 import { PropTypes } from "react";
 
-import { safeClient } from "../ts/util";
+import { safeClient, WATCH_URL_RE } from "../ts/util";
 import { Maybe } from "../ts/maybe";
 const sc = safeClient;
 
@@ -120,7 +120,7 @@ export class Watch extends React.Component<WatchProps, WatchState> {
     }
 
     private mkVideo(props): Promise<Video> {
-        const match: string[] = /\/watch\/([a-zA-Z0-9\/\+]+=*)/.exec(props.location.pathname);
+        const match: string[] = WATCH_URL_RE.exec(props.location.pathname);
         if (match.length !== 2) {
             return Promise.reject(new Error("Watch: bad path"));
         }

--- a/app/client/ts/util.ts
+++ b/app/client/ts/util.ts
@@ -11,6 +11,8 @@ export type ValidationState = "error" | "success" | "warning";
 export const safeClient: SafeClient =
     new SafeClient(CONFIG.makeAuthPayload(), CONFIG.SAFE_LAUNCHER_ENDPOINT);
 
+export const WATCH_URL_RE: RegExp = /\/watch\/([a-zA-Z0-9\/\+]+)/;
+
 export async function fileExists(path: string): Promise<boolean> {
     return new Promise<boolean>( (resolve, reject) => {
         fs.stat(path, (err, stat) => {


### PR DESCRIPTION
In light of @Abdisalan's comment about the unsightly console.log() call in Upload.tsx, I made sure that the FramesURLBar is consistent with the current route. Now we can copy-paste frames URLs from the FramesURLBar like we are in a browser. This is exciting.