### PR TITLE
WIP: Thumbnails

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Senior Design Project: Safenet
+# Frames
 
-Building a database framework for use on the SafeNet.
+A native video sharing app for the SafeNET.
 
 [![Build Status](https://travis-ci.org/Frames-Proj/frames.svg?branch=master)](https://travis-ci.org/Frames-Proj/frames)
 
@@ -9,9 +9,26 @@ Building a database framework for use on the SafeNet.
 2. Make pull requests (must be approved by another person)
 3. Make sure to use the issue tracker and apply the appropriate label
 
+## Testing
+
+We use the safe_launcher compiled with mock routing in order to test
+the app. We use `safe_client_libs` commit `7e21447bb706e5bf81141a204fc761ccf42fa04e`
+and `safe_launcher` commit `8f3414b77be0766e6e935a072c9b2ff4244dfce7`. The
+app depends on `ffmpeg` being on your path. To test the launcher client we have
+written you can type `cd db/low-level && make setup && make test`. To run the app tests, you
+can type `cd app && make setup && make test`. In both cases we require that
+you have the safe_launcher running before you run the tests. You will be asked
+to authenticate on each test run. The app tests depend on having the `file`
+command on your path. It should be built in to most *nix distributions.
+
 ## Installation/Usage
 
-Coming Soon.
+You can build the mock launcher with the information provided above. Once you run the
+tests, you should be able to just type `npm start` in the `app` directory.
+
+## Tech Stack
+
+Frames is written in TypeScript and built using Electron (we're sorry).
 
 ## Team Members
 

--- a/app/client/components/VideoThumbnail.tsx
+++ b/app/client/components/VideoThumbnail.tsx
@@ -11,6 +11,7 @@ interface VideoThumbnailProps {
 
 interface VideoThumbnailState {
     resolvedVideo: Maybe<Video>;
+    resolvedVideoThumbnail: Maybe<string>;
     videoIsBad: boolean;
 }
 
@@ -30,11 +31,16 @@ export default class VideoThumbnail extends React.Component<VideoThumbnailProps,
         super(props);
 
         Video.readFromStringXorName(props.xorName, false)
-             .then(v => this.setState({ resolvedVideo: Maybe.just(v) }))
+             .then((v: Video) => {
+                 this.setState({ resolvedVideo: Maybe.just(v) });
+                 v.thumbnailFile.then((tf: string) =>
+                     this.setState({ resolvedVideoThumbnail: Maybe.just(tf) }));
+             })
              .catch(_ => this.setState({ videoIsBad: true }));
 
         this.state = {
             resolvedVideo: Maybe.nothing<Video>(),
+            resolvedVideoThumbnail: Maybe.nothing<string>(),
             videoIsBad: false
         };
     }
@@ -63,9 +69,12 @@ export default class VideoThumbnail extends React.Component<VideoThumbnailProps,
                         }}>
                             <div style={{
                                 height: "100px",
-                                width: "150px",
-                                background: "black"
+                                width: "150px"
                             }}>
+                                {this.state.resolvedVideoThumbnail.caseOf({
+                                    nothing: () => <ChasingArrowsLoadingImage />,
+                                    just: t => <img src={t} />
+                                })}
                             </div>
                             <span>
                                 { v.title }

--- a/app/client/ts/global-config.ts
+++ b/app/client/ts/global-config.ts
@@ -31,7 +31,9 @@ export default class Config {
 
     public readonly APP_HOME_DIR: string = "/tmp/frames-home";
     public readonly APP_VIDEO_DIR: string = this.APP_HOME_DIR + "/video-cache";
+    public readonly APP_THUMBNAIL_DIR: string = this.APP_HOME_DIR + "/thumbnail-cache";
     public readonly SAFENET_VIDEO_DIR: string = "videos";
+    public readonly SAFENET_THUMBNAIL_DIR: string = "thumbnails";
     public readonly APP_NAME: string = "Frames";
 
     // long name stuff. We thought we would avoid global state...

--- a/app/client/ts/spec/comment-model-spec.ts
+++ b/app/client/ts/spec/comment-model-spec.ts
@@ -3,6 +3,7 @@ import { TEST_DATA_DIR, failDone, makeid, checkForLeakErrors } from "./test-util
 
 import VideoComment from "../comment-model";
 import Video from "../video-model";
+import { Maybe } from "../maybe";
 
 import Config from "../global-config";
 const CONFIG: Config = Config.getInstance();
@@ -22,6 +23,7 @@ describe("A video comment model", () => {
     beforeAll(async (done) => {
         await failDone(startupHook(), done);
         setCollectLeakStats();
+        CONFIG.setLongName(Maybe.just("uwotm8"));
         done();
     });
 
@@ -83,7 +85,7 @@ describe("A video comment model", () => {
                 await sc.dataID.deserialise(xorName), d => VideoComment.read(d)), done);
 
         expect(deserialComment.text).toBe(comment.text);
-        expect(deserialComment.date).toBe(comment.date);
+        expect(deserialComment.date.getTime()).toBe(comment.date.getTime());
         expect(deserialComment.parentVersion).toBe(comment.parentVersion);
         expect((await deserialComment.parent.serialise())
                .equals(await comment.parent.serialise())).toBe(true);
@@ -116,7 +118,7 @@ describe("A video comment model", () => {
                 await sc.dataID.deserialise(xorName), d => VideoComment.read(d)), done);
 
         expect(deserialComment.text).toBe(comment.text);
-        expect(deserialComment.date).toBe(comment.date);
+        expect(deserialComment.date.getTime()).toBe(comment.date.getTime());
         expect(deserialComment.parentVersion).toBe(comment.parentVersion);
         expect((await deserialComment.parent.serialise())
                .equals(await comment.parent.serialise())).toBe(true);

--- a/app/client/ts/spec/playlist-model-spec.ts
+++ b/app/client/ts/spec/playlist-model-spec.ts
@@ -3,6 +3,7 @@ import { TEST_DATA_DIR, failDone, makeid, checkForLeakErrors } from "./test-util
 
 import Playlist from "../playlist-model";
 import Video from "../video-model";
+import { Maybe } from "../maybe";
 
 import Config from "../global-config";
 const CONFIG: Config = Config.getInstance();
@@ -21,6 +22,7 @@ describe("A playlist model", () => {
     beforeAll(async (done) => {
         await failDone(startupHook(), done);
         setCollectLeakStats();
+        CONFIG.setLongName(Maybe.just("uwotm8"));
         done();
     });
 

--- a/app/client/ts/spec/test-util.ts
+++ b/app/client/ts/spec/test-util.ts
@@ -1,5 +1,7 @@
 
 import { LeakResults, getLeakStatistics } from "safe-launcher-client";
+import { makeRandAlphaStr, makeRandStr } from "../util";
+import * as fs from "fs";
 
 export const TEST_DATA_DIR: string = `${__dirname}/../../client/ts/spec/test-data`;
 
@@ -11,24 +13,8 @@ export function failDone<T>(promise: Promise<T>,
     });
 }
 
-function buildString(possibleChars: string, finalLength: number) {
-    let text = "";
-    for (let i = 0; i < finalLength; i++) {
-        text += possibleChars.charAt(Math.floor(Math.random() * possibleChars.length));
-    }
-    return text;
-}
-
-export function makeid() {
-    let possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-
-    return buildString(possible, 15);
-}
-
-export function makeAlphaid() {
-    let possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
-    return buildString(possible, 15);
-}
+export const makeid = makeRandStr;
+export const makeAlphaid = makeRandAlphaStr;
 
 export function checkForLeakErrors(): void {
     const leakStats: LeakResults = getLeakStatistics();
@@ -43,6 +29,24 @@ export function checkForLeakErrors(): void {
             }
         }
     }
+}
+
+export async function diffFiles(f1: string, f2: string): Promise<boolean> {
+    return new Promise<boolean>((resolve, reject) => {
+        fs.readFile(f1, (err, b1) => {
+            if (err) {
+                reject(err);
+            } else {
+                fs.readFile(f2, (err, b2) => {
+                    if (err) {
+                        reject(err);
+                    } else {
+                        resolve(b1.equals(b2));
+                    }
+                });
+            }
+        });
+    });
 }
 
 export function sleep(ms) {

--- a/app/client/ts/spec/thumbnail-spec.ts
+++ b/app/client/ts/spec/thumbnail-spec.ts
@@ -1,0 +1,19 @@
+
+import extractThumbnail from "../thumbnail";
+import { TEST_DATA_DIR } from "./test-util";
+import { exec } from "child_process";
+import * as fs from "fs";
+import { makeid } from "./test-util";
+
+describe("getThumbnail", () => {
+    it("can get a thumbnail image for an mp4 on node", (done) => {
+        extractThumbnail(`${TEST_DATA_DIR}/test-vid.mp4`).then(thumbnail => {
+            exec(`file ${thumbnail}`, (err, stdout, stderr) => {
+                expect(err).toBeNull();
+                expect(/PNG image data/.test(stdout)).toBeTruthy();
+                done();
+            });
+        });
+    });
+});
+

--- a/app/client/ts/startup-hooks.ts
+++ b/app/client/ts/startup-hooks.ts
@@ -15,8 +15,15 @@ import * as mkpath from "mkpath";
 
 export default async function startupHook(): Promise<void> {
     await ensureVideoCache();
+    await ensureThumbnailCache();
+
     await ensureSafeVideoDir();
+    await ensureSafeThumbnailDir();
 }
+
+//
+// Ensure the right environment on the local box
+//
 
 function ensureVideoCache(): Promise<void> {
     return new Promise<void>((resolve, reject) => {
@@ -27,12 +34,32 @@ function ensureVideoCache(): Promise<void> {
     });
 }
 
-async function ensureSafeVideoDir(): Promise<void> {
+function ensureThumbnailCache(): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+        mkpath(CONFIG.APP_THUMBNAIL_DIR, 755, (err) => {
+            if (err) reject(err);
+            else resolve();
+        });
+    });
+}
+
+
+
+//
+// Ensure the right environment on the SafeNET
+//
+
+function ensureSafeVideoDir(): Promise<void> {
     return safeClient.nfs.dir.create("app", CONFIG.SAFENET_VIDEO_DIR, false).catch(err => {
         if (err.res.statusCode === 400) {
             // the directory already exists! Yay!
             return;
         }
     });
+}
+
+function ensureSafeThumbnailDir(): Promise<void> {
+    return safeClient.nfs.dir.create("app", CONFIG.SAFENET_THUMBNAIL_DIR, false)
+        .catch(err => { if (err.res.statusCode === 400) return; });
 }
 

--- a/app/client/ts/thumbnail.ts
+++ b/app/client/ts/thumbnail.ts
@@ -1,0 +1,31 @@
+//
+// Generate a video thumbnail from a video file.
+//
+
+import { exec } from "child_process";
+import { makeRandStr } from "./util";
+import * as fs from "fs";
+
+
+export class FfmepgCommandFailed extends Error {
+    public err: any;
+    constructor(message: string, err: any) {
+        super(message);
+        this.err = err;
+    }
+}
+
+//
+// A function from a path to a video file to a promise to a
+// path the the thumbnail file.
+//
+export default function extractThumbnail(videoFile: string): Promise<string> {
+    const tmpFile: string = `/tmp/frames-tmp-thumbnail-${makeRandStr()}.png`;
+    return new Promise((resolve, reject) => {
+        exec(`ffmpeg -i ${videoFile} -ss 00:00:00 -vf scale=200:-1 -vframes 1 ${tmpFile}`,
+                (err, stdout, stderr) => {
+            if (err) reject(new FfmepgCommandFailed("Ffmpeg command failed.", err));
+            else resolve(tmpFile);
+        });
+    });
+}

--- a/app/client/ts/util.ts
+++ b/app/client/ts/util.ts
@@ -34,3 +34,22 @@ export async function fileExists(path: string): Promise<boolean> {
         });
     });
 }
+
+function buildString(possibleChars: string, finalLength: number) {
+    let text = "";
+    for (let i = 0; i < finalLength; i++) {
+        text += possibleChars.charAt(Math.floor(Math.random() * possibleChars.length));
+    }
+    return text;
+}
+
+export function makeRandStr() {
+    let possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+    return buildString(possible, 15);
+}
+
+export function makeRandAlphaStr() {
+    let possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    return buildString(possible, 15);
+}


### PR DESCRIPTION
This impliments the refactoring described in #90, and adds support for thumbnails using ffmpeg as described in #85 (I was unable to easily use make thumbnails using the browser API, but the internet seems to indicate it is possible). I want to take a crack at removing the dependency on ffmpeg (though nor for the model tests because that is a node-only environment). As of the time I open this PR, the code touches a lot of things, and I want to try to cut down on the churn before this gets merged. I also want to squash several commits that do not represent meaningful changes. Please don't merge this till I remove the WIP from the title.  

This PR also gets several of the tests passing which were broken by previous changes.