### PR TITLE
Cached appdat

### DIFF
--- a/app/client/components/Comments.tsx
+++ b/app/client/components/Comments.tsx
@@ -173,9 +173,6 @@ export default class ReplyTree extends React.Component<CommentsProps, CommentsSt
                 commentValue: ''
             });
             this.setComments(this.props.video);
-        }).catch(err => {
-            console.error(err)
-            throw err;
         });
 
     }

--- a/app/client/components/Watch.tsx
+++ b/app/client/components/Watch.tsx
@@ -56,6 +56,7 @@ class VideoPlayer extends React.Component<VideoPlayerProps, VideoPlayerState> {
     }
 
     componentWillReceiveProps(nextProps: VideoPlayerProps): void {
+        this.setState({ resolvedVideo: Maybe.nothing<ResolvedVideo>() });
         this.resolveVideo(nextProps);
     }
 
@@ -160,8 +161,10 @@ export class Watch extends React.Component<WatchProps, WatchState> {
     }
 
     componentWillReceiveProps(nextProps: WatchProps) {
-        this.state.video.then( v => v.drop() );
-        this.setState({ video: this.mkVideo(nextProps).catch(this.handleVideoError) });
+        this.state.video.then( v => {
+            v.drop();
+            this.setState({ video: this.mkVideo(nextProps).catch(this.handleVideoError) });
+        });
     }
 
     private handleVideoError(err) {

--- a/app/client/ts/cached-appendable-data.ts
+++ b/app/client/ts/cached-appendable-data.ts
@@ -1,0 +1,77 @@
+//
+// A wrapper around appendable-data which maintains a cache of
+// the DataIDHandles that have been appended.
+//
+
+import { Drop, AppendableDataHandle, FromDataIDHandleResponse
+         , withDropP, withDrop, DataIDHandle, AppedableDataMetadata } from "safe-launcher-client";
+import { safeClient as sc } from "./util";
+
+export default class CachedAppendableDataHandle implements Drop {
+    private _cache: DataIDHandle[];
+    private _handle: AppendableDataHandle;
+    public constructor(private _handleInfo: FromDataIDHandleResponse) {
+        this._handle = _handleInfo.handleId;
+        this._cache = [];
+    }
+
+    // basic property accessors
+    public get length(): number {
+        return this._handleInfo.dataLength + this._cache.length;
+    }
+    public getMetadata(): Promise<AppedableDataMetadata> { return this._handle.getMetadata(); }
+    public save() { return this._handle.save(); }
+    public toDataIdHandle() { return this._handle.toDataIdHandle(); }
+    public update() { return this._handle.update(); }
+    public drop(): Promise<void> {
+        for (let i: number = 0; i < this._cache.length; ++i) {
+            this._cache[i].drop();
+        }
+        return this._handle.drop();
+    }
+
+    public at(i: number): Promise<DataIDHandle> {
+        if (i >= this.length || i < 0)
+            throw new Error(`CachedAppendableDataHandle::at(${i}) index not in range!`);
+
+        if (i >= this._handleInfo.dataLength) {
+            return Promise.resolve(this._cache[i - this._handleInfo.dataLength]);
+        } else {
+            return this._handle.at(i);
+        }
+    }
+
+
+    // If the DataIDHandle at the given index is cached, `withAt`
+    // just applies the given function, but otherwise it also drops
+    // the generated DataIDHandle
+    //
+    // @param i - the index in the CachedAppendableDataHandle to apply `f` to
+    // @param f - the function to apply
+    // @returns the result of the given function
+    public async withAt<T>(i: number, f: (hdl: DataIDHandle) => Promise<T>): Promise<T> {
+        if (i >= this.length || i < 0)
+            throw new Error(`CachedAppendableDataHandle::withAt(${i}) index not in range!`);
+
+        if (i >= this._handleInfo.dataLength) {
+            return f(this._cache[i - this._handleInfo.dataLength]);
+        } else {
+            const did = await this._handle.at(i);
+            return f(did)
+                .then(async x => { await did.drop(); return x; })
+                .catch(async err => { await did.drop(); throw err; });
+        }
+    }
+
+    public append(x: DataIDHandle): Promise<void> {
+        // only append to the cache when the promise resolves
+        return this._handle.append(x)
+            .then(_ => { this._cache.push(x); return; });
+    }
+
+    public static async new(xorName: DataIDHandle): Promise<CachedAppendableDataHandle> {
+        return new CachedAppendableDataHandle(await sc.ad.fromDataIdHandle(xorName));
+    }
+}
+
+

--- a/app/client/ts/spec/cached-appendable-data-spec.ts
+++ b/app/client/ts/spec/cached-appendable-data-spec.ts
@@ -1,0 +1,84 @@
+//
+//
+
+
+import { TEST_DATA_DIR, failDone, makeid, checkForLeakErrors, diffFiles } from "./test-util";
+
+import Video from "../video-model";
+import { Maybe } from "../maybe";
+
+import CachedAppendableDataHandle from "../cached-appendable-data";
+
+import Config from "../global-config";
+const CONFIG: Config = Config.getInstance();
+
+import { TYPE_TAG_VERSIONED, DataIDHandle,
+         SerializedDataID, withDropP, StructuredDataHandle,
+         setCollectLeakStats, setCollectLeakStatsBlock,
+         AppendableDataHandle
+       } from "safe-launcher-client";
+import { safeClient as sc } from "../util";
+
+import startupHook from "../startup-hooks";
+
+describe("A cached appendable data.", () => {
+
+    beforeAll(async (done) => {
+        await failDone(startupHook(), done);
+        setCollectLeakStats();
+        CONFIG.setLongName(Maybe.just("uwotm8"));
+        done();
+    });
+
+    it("can be created", async done => {
+        setCollectLeakStatsBlock("cad:1 creation");
+
+        const appdat: AppendableDataHandle =
+            await failDone(sc.ad.create("Some name" + makeid()), done);
+        await failDone(appdat.save(), done);
+        const cachedAppdat: CachedAppendableDataHandle =
+            await failDone(withDropP(await appdat.toDataIdHandle(),
+                                     did => CachedAppendableDataHandle.new(did)), done);
+        await failDone(cachedAppdat.drop(), done);
+
+        done();
+    });
+
+    it("can be appended to", async done => {
+        setCollectLeakStatsBlock("cad:2 append");
+
+        const appdat: AppendableDataHandle =
+            await failDone(sc.ad.create("Some name" + makeid()), done);
+        await failDone(appdat.save(), done);
+        const cachedAppdat: CachedAppendableDataHandle =
+            await failDone(withDropP(await appdat.toDataIdHandle(),
+                                     did => CachedAppendableDataHandle.new(did)), done);
+
+        const sd1 = await failDone(
+            sc.structured.create("sd1" + makeid(), TYPE_TAG_VERSIONED, "u wot m8"), done);
+        await sd1.save();
+        await failDone(cachedAppdat.append(await sd1.toDataIdHandle()), done);
+
+        expect(cachedAppdat.length).toBe(1);
+
+        const recoveredSd = await failDone(sc.structured.fromDataIdHandle(await cachedAppdat.at(0)), done);
+
+        const sd1Content = await failDone(sd1.read(), done);
+        const recoveredSdContent = await failDone(recoveredSd.handleId.read(), done);
+
+        expect(sd1Content).toBe(recoveredSdContent);
+
+        const sd2 = await failDone(
+            sc.structured.create("sd2" + makeid(), TYPE_TAG_VERSIONED, "u wot m8"), done);
+        await sd2.save();
+        await failDone(cachedAppdat.append(await sd2.toDataIdHandle()), done);
+
+        expect(cachedAppdat.length).toBe(2);
+
+        await failDone(cachedAppdat.drop(), done);
+        await failDone(sd1.drop(), done);
+        await failDone(sd2.drop(), done);
+
+        done();
+    });
+});

--- a/app/client/ts/video-model.ts
+++ b/app/client/ts/video-model.ts
@@ -55,7 +55,7 @@ export default class Video implements Drop {
         return Promise.resolve(this.commentReplies.length);
     }
     public getComment(i: number): Promise<VideoComment> {
-        return this.commentReplies.withAt(i, did => VideoComment.read(did);
+        return this.commentReplies.withAt(i, did => VideoComment.read(did));
     }
     public async getCommentXorName(i: number): Promise<string> {
         return this.commentReplies.withAt(i, async did => (await did.serialise()).toString("base64"));

--- a/db/low-level/index.ts
+++ b/db/low-level/index.ts
@@ -31,6 +31,9 @@ import { DataIDClient, DataIDHandle, SerializedDataID } from "./src/ts/data-id";
 import { Drop, withDrop, withDropP, Handle, setCollectLeakStats,
          setCollectLeakStatsBlock, getLeakStatistics, LeakResults
        } from "./src/ts/raii";
+import { InvalidHandleError, SafeError, NotFoundError, UnexpectedResponseContent
+       } from "./src/ts/util";
+
 
 export { NfsClient, NfsFileClient, NfsDirectoryClient,
          NfsDirectoryData, NfsDirectoryInfo, NfsFileData, AuthorizationPayload,
@@ -39,7 +42,8 @@ export { NfsClient, NfsFileClient, NfsDirectoryClient,
          TYPE_TAG_VERSIONED, TYPE_TAG_UNVERSIONED, SerializedDataID,
          StructuredDataMetadata, setCollectLeakStats, setCollectLeakStatsBlock,
          getLeakStatistics, LeakResults, FromDataIDHandleResponse, ApiClientConfig,
-         StructuredDeserialiseResponse, DnsClient, DnsHomeDirectory
+         StructuredDeserialiseResponse, DnsClient, DnsHomeDirectory, InvalidHandleError,
+         SafeError, NotFoundError, UnexpectedResponseContent
        };
 
 

--- a/db/low-level/src/ts/appendable-data.ts
+++ b/db/low-level/src/ts/appendable-data.ts
@@ -300,8 +300,7 @@ export class AppendableDataHandle extends Handle {
      *
      */
     protected async dropImpl(): Promise<void> {
-        if (!this.valid)
-            throw new InvalidHandleError(this.handle, "AppendableDataHandle:dropImpl");
+        if (!this.valid) return; // we want drop to be idempotent. It lets us be imprecise about ownership
 
         const result = await saneResponse(WebRequest.create<any>(
             `${this.client.adEndpoint}/handle/${this.handle}`, {

--- a/db/low-level/src/ts/data-id.ts
+++ b/db/low-level/src/ts/data-id.ts
@@ -97,8 +97,7 @@ export class DataIDHandle extends Handle {
      *
      */
     protected async dropImpl(): Promise<void> {
-        if (!this.valid)
-            throw new InvalidHandleError(this.handle, "DataIDHandle:dropImpl");
+        if (!this.valid) return; // we want drop to be idempotent. It lets us be imprecise about ownership
 
         const result = await saneResponse(WebRequest.create<any>(
             `${this.client.endpoint}/data-id/${this.handle}`, {

--- a/db/low-level/src/ts/structured-data.ts
+++ b/db/low-level/src/ts/structured-data.ts
@@ -277,8 +277,7 @@ export class StructuredDataHandle extends Handle {
      * @param handle - the structured data handle
      */
     protected async dropImpl(): Promise<void> {
-        if (!this.valid)
-            throw new InvalidHandleError(this.handle, "StructuredDataHandle:dropImpl");
+        if (!this.valid) return; // we want drop to be idempotent. It lets us be imprecise about ownership
 
         const result = await saneResponse(WebRequest.create<any>(
             `${this.client.sdEndpoint}/handle/${this.handle}`, {


### PR DESCRIPTION
This commit adds a CachedAppendableDataHandle class which gives appendable data the semantics that we know it should have.

Ownership of the cached DataIDHandles can be a little
tricky. The CachedAppendableDataHandle has to own the
cached handles to make sure that they don't get dropped,
but it does not own the data handles that actually live
on the SafeNET. To work around this there is a method
called `withAt` that lets you execute a function in terms
of a given DataIDHandle. The handle is garenteed to live
long enough for the promise returned by the given callback
to complete.
