### PR TITLE
Updated VideoThumbnail to accept raw parts as well as simply an XorName

### DIFF
--- a/app/client/components/ReplyTree.tsx
+++ b/app/client/components/ReplyTree.tsx
@@ -4,7 +4,7 @@ import { Upload } from "./Upload";
 import Video from "../ts/video-model"
 import { SerializedDataID, withDropP } from "safe-launcher-client";
 import { ChasingArrowsLoadingImage } from "./Animations";
-import VideoThumbnail from "./VideoThumbnail"
+import VideoThumbnail, { VTArg } from "./VideoThumbnail"
 import { PropTypes } from "react";
 
 import { safeClient, WATCH_URL_RE } from "../ts/util";
@@ -49,7 +49,7 @@ export default class ReplyTree extends React.Component<ReplyTreeProps, ReplyTree
          v.parentVideoXorName.caseOf({
             nothing: () => {},
             just: name => {this.setState({ parent: Maybe.just(
-                <VideoThumbnail xorName={name} />)
+                <VideoThumbnail arg={new VTArg(name)} />)
             })}
          });
     }
@@ -69,7 +69,7 @@ export default class ReplyTree extends React.Component<ReplyTreeProps, ReplyTree
             this.setState({ replies: Maybe.just(replies) });
         } else {
             v.getReplyVideoXorName(curr).then(name => {
-                replies.push(<VideoThumbnail xorName={name} />);
+                replies.push(<VideoThumbnail arg={new VTArg(name)} />);
                 this.getAllReplies(v, curr + 1, total, replies);
             });
         }

--- a/app/client/components/VideoThumbnail.tsx
+++ b/app/client/components/VideoThumbnail.tsx
@@ -5,15 +5,40 @@ import { ChasingArrowsLoadingImage } from "./Animations";
 import { Maybe } from "../ts/maybe";
 import { PropTypes } from "react";
 
+
+export class VTArg {
+    private kind: "xorName" | "rawPayload";
+    constructor(private _d: string | VideoThumbnailPayload) {
+        if (typeof _d === "string") this.kind = "xorName";
+        else if (_d instanceof VideoThumbnailPayload) this.kind = "rawPayload";
+        else throw new Error("Type error.");
+    }
+    public caseOf<T>(cases: { xorName: (xorName: string) => T,
+                              rawPayload: (rawPayload: VideoThumbnailPayload) => T }): T {
+        if (this.kind === "xorName") return cases.xorName(this._d as string);
+        else if (this.kind === "rawPayload") return cases.rawPayload(this._d as VideoThumbnailPayload);
+    }
+
+}
+
 interface VideoThumbnailProps {
-    xorName: string;
+    arg: VTArg;
 }
 
 interface VideoThumbnailState {
-    resolvedVideo: Maybe<Video>;
-    resolvedVideoThumbnail: Maybe<string>;
+    /* resolvedVideo: Maybe<Video>;
+     * resolvedVideoThumbnail: Maybe<string>;*/
+    payload: Maybe<VideoThumbnailPayload>;
     videoIsBad: boolean;
 }
+
+// all the data a `VideoThumbnail` really needs to work.
+class VideoThumbnailPayload {
+    constructor(public title: string,
+                public owner: string,
+                public thumbnailFile: string,
+                public xorName: string) {}
+};
 
 export default class VideoThumbnail extends React.Component<VideoThumbnailProps, VideoThumbnailState> {
 
@@ -30,24 +55,28 @@ export default class VideoThumbnail extends React.Component<VideoThumbnailProps,
     constructor(props: VideoThumbnailProps) {
         super(props);
 
-        Video.readFromStringXorName(props.xorName, false)
-             .then((v: Video) => {
-                 this.setState({ resolvedVideo: Maybe.just(v) });
-                 v.thumbnailFile.then((tf: string) =>
-                     this.setState({ resolvedVideoThumbnail: Maybe.just(tf) }));
-             })
-             .catch(_ => this.setState({ videoIsBad: true }));
-
         this.state = {
-            resolvedVideo: Maybe.nothing<Video>(),
-            resolvedVideoThumbnail: Maybe.nothing<string>(),
+            payload: Maybe.nothing<VideoThumbnailPayload>(),
             videoIsBad: false
         };
+
+        props.arg.caseOf<Promise<void> | void>({
+            xorName: n =>
+                Video.readFromStringXorName(n, false)
+                    .then((v: Video) => v.thumbnailFile.then((tf: string) =>
+                        this.setState({ payload: Maybe.just(new VideoThumbnailPayload(
+                        v.title, v.owner, tf, n))})))
+                    .catch(_ => this.setState({ videoIsBad: true })),
+            rawPayload: rp => this.setState({ payload: Maybe.just(rp) })
+        });
     }
 
     private onClick(e): void {
         e.preventDefault();
-        this.context.router.history.push(`/watch/${this.props.xorName}`);
+        this.state.payload.caseOf({
+            nothing: () => null, // if we have not loaded yet, the link should not be live
+            just: p => this.context.router.history.push(`/watch/${p.xorName}`)
+        });
     }
 
     render() {
@@ -60,9 +89,9 @@ export default class VideoThumbnail extends React.Component<VideoThumbnailProps,
                 textAlign: "center",
                 margin: "0px 20px 0px 20px"
             }}> X </span>
-            : this.state.resolvedVideo.caseOf({
+            : this.state.payload.caseOf({
                 nothing: () => <ChasingArrowsLoadingImage />,
-                just: v => (
+                just: p => (
                     <div>
                         <a href="#" onClick={this.onClick.bind(this)} style={{
                             cursor: "pointer"
@@ -71,20 +100,17 @@ export default class VideoThumbnail extends React.Component<VideoThumbnailProps,
                                 height: "100px",
                                 width: "150px"
                             }}>
-                                {this.state.resolvedVideoThumbnail.caseOf({
-                                    nothing: () => <ChasingArrowsLoadingImage />,
-                                    just: t => <img src={t} />
-                                })}
+                                <img src={p.thumbnailFile} />
                             </div>
                             <span>
-                                { v.title }
+                                { p.title }
                             </span>
                         </a>
                         <div style={{
                             fontSize: "12px",
                             color: "gray"
                         }}>
-                            { v.owner }
+                            { p.owner }
                         </div>
                     </div>)
             });

--- a/app/client/components/VideosList.tsx
+++ b/app/client/components/VideosList.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import VideoThumbnail from "./VideoThumbnail";
+import VideoThumbnail, { VTArg } from "./VideoThumbnail";
 
 export class VideosList extends React.Component<{}, {}> {
 
@@ -17,10 +17,10 @@ export class VideosList extends React.Component<{}, {}> {
         var videos: JSX.Element[] = [
             // sports
             <VideoThumbnail
-                xorName={"AdafsAAAAAAAAAAAAAAg7pUk7oRUjt4UnccreklFfuYF3ZQzc2RcRLHmAwpieIAAAAAAAAAB9Q"} />,
+                arg={new VTArg("AdafsAAAAAAAAAAAAAAg7pUk7oRUjt4UnccreklFfuYF3ZQzc2RcRLHmAwpieIAAAAAAAAAB9Q")} />,
             // art
             <VideoThumbnail
-                xorName={"AAAAAAAAAAAAAAAgINq3PEnkFVN7CH0waEGtg+LP+h7Kup9poR6hueNrCQAAAAAAAAAB9Q"} />
+                arg={new VTArg("AAAAAAAAAAAAAAAgINq3PEnkFVN7CH0waEGtg+LP+h7Kup9poR6hueNrCQAAAAAAAAAB9Q")} />
         ];
 
         return (


### PR DESCRIPTION
This adds a tagged union called VTArg which becomes the sole property of
VideoThumbnail, replacing `xorName`. VTArg has a smart constructor, so
it should be very smooth to use either option. All the old uses of
VideoThumbnail have been updated to reflect the changes.